### PR TITLE
Use the Creative Commons SPDX IDs in the license metadata

### DIFF
--- a/rules/BRLY-2021-001-SwSmi-LEN-65529.yml
+++ b/rules/BRLY-2021-001-SwSmi-LEN-65529.yml
@@ -1,7 +1,7 @@
 BRLY-2021-001-SwSmi-LEN-65529:
   meta:
     author:       Binarly (https://github.com/binarly-io/FwHunt)
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         BRLY-2021-001
     version:      1.0
     namespace:    vulnerabilities

--- a/rules/BSSA-DFT-INTEL-SA-00525.yml
+++ b/rules/BSSA-DFT-INTEL-SA-00525.yml
@@ -1,7 +1,7 @@
 Intel-BSSA-DFT-INTEL-SA-00525:
   meta:
     author:       Binarly (https://github.com/binarly-io/FwHunt)
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         Intel-BSSA-DFT
     version:      1.0
     namespace:    vulnerabilities

--- a/rules/ThinkPwn-LEN-8324.yml
+++ b/rules/ThinkPwn-LEN-8324.yml
@@ -1,7 +1,7 @@
 ThinkPwn:
   meta:
     author:       Binarly (https://github.com/binarly-io/FwHunt)
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         ThinkPwn
     version:      2.0
     namespace:    vulnerabilities

--- a/rules/UsbRt-CVE-2017-5721.yml
+++ b/rules/UsbRt-CVE-2017-5721.yml
@@ -1,7 +1,7 @@
 UsbRt-CVE-2017-5721:
   meta:
     author:       Binarly (https://github.com/binarly-io/FwHunt)
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         UsbRt-CVE-2017-5721
     version:      1.0
     namespace:    vulnerabilities

--- a/rules/UsbRt-INTEL-SA-00057.yml
+++ b/rules/UsbRt-INTEL-SA-00057.yml
@@ -1,7 +1,7 @@
 UsbRt-INTEL-SA-00057:
   meta:
     author:       Binarly (https://github.com/binarly-io/FwHunt)
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         UsbRt-INTEL-SA-00057
     version:      1.0
     namespace:    vulnerabilities

--- a/rules/UsbRt-SwSmi-CVE-2020-12301.yml
+++ b/rules/UsbRt-SwSmi-CVE-2020-12301.yml
@@ -1,7 +1,7 @@
 UsbRt-SwSmi-CVE-2020-12301:
   meta:
     author:       Binarly
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         UsbRt-SwSmi-CVE-2020-12301
     version:      1.0
     namespace:    vulnerabilities

--- a/rules/UsbRt-UsbSmi-CVE-2020-12301.yml
+++ b/rules/UsbRt-UsbSmi-CVE-2020-12301.yml
@@ -1,7 +1,7 @@
 UsbRt-UsbSmi-CVE-2020-12301:
   meta:
     author:       Binarly
-    license:      https://creativecommons.org/publicdomain/zero/1.0/
+    license:      CC0-1.0
     name:         UsbRt-UsbSmi-CVE-2020-12301
     version:      1.0
     namespace:    vulnerabilities


### PR DESCRIPTION
It was quite unusual to find a URL for a value that's supposed to be
machine readable. Just use the standardized SPDX ID instead.