### PR TITLE
Add volume guids metadata to various rules

### DIFF
--- a/rules/BRLY-2021-001-SwSmi-LEN-65529.yml
+++ b/rules/BRLY-2021-001-SwSmi-LEN-65529.yml
@@ -9,6 +9,8 @@ BRLY-2021-001-SwSmi-LEN-65529:
     vendor id:    LEN-65529
     advisory:     https://binarly.io/advisories/BRLY-2021-001/index.html
     description:  SMM callout vulnerability on Lenovo ThinkPad laptops firmware (SMM arbitrary code execution)
+    volume guids:
+      - 658d56f0-4364-4721-b70e-732ddc8a2771
   code:
     0:
       pattern: 488b05....000033d24533c98d4a024533c0ff5068

--- a/rules/BSSA-DFT-INTEL-SA-00525.yml
+++ b/rules/BSSA-DFT-INTEL-SA-00525.yml
@@ -11,6 +11,8 @@ Intel-BSSA-DFT-INTEL-SA-00525:
     advisory:     https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00525.html
     url:          https://binarly.io/posts/Detecting_Firmware_vulnerabilities_at_scale_Intel_BSSA_DFT_case_study
     description:  Intel BSSA DFT detection
+    volume guids:
+      - d71c8ba4-4af2-4d0d-b1ba-f2409f0c20d3
   guids:
     - 0:
       - name: EFI_PLATFORM_INFO_GUID

--- a/rules/ThinkPwn-LEN-8324.yml
+++ b/rules/ThinkPwn-LEN-8324.yml
@@ -9,6 +9,8 @@ ThinkPwn:
     advisory:     https://support.lenovo.com/my/en/solutions/LEN-8324
     url:          https://github.com/Cr4sh/ThinkPwn/
     description:  Detection for ThinkPwn vulnerability
+    volume guids:
+      - 7c79ac8c-5e6c-4e3d-ba6f-c260ee7c172e
   hex_strings:
     0: 4d95901395da274293287282c217daa8 # EFI_SMM_BASE_PROTOCOL_GUID
     1: 488b4220488bda4885c0....488b084c8d4218488b15........ff5008488363200033c0

--- a/rules/UsbRt-CVE-2017-5721.yml
+++ b/rules/UsbRt-CVE-2017-5721.yml
@@ -10,6 +10,8 @@ UsbRt-CVE-2017-5721:
     CVSS score:   7.5 High
     advisory:     https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00084.html
     description:  Detection for SMM callout in SW SMI handler on multiple Intel server platforms
+    volume guids:
+      - 04eaaaa1-29a1-11d7-8838-00500473d4eb
   code:
     0:
       pattern: 0fb704250e040000ba2f000000c1e00405040100008b38

--- a/rules/UsbRt-INTEL-SA-00057.yml
+++ b/rules/UsbRt-INTEL-SA-00057.yml
@@ -8,6 +8,8 @@ UsbRt-INTEL-SA-00057:
     vendor id:    INTEL-SA-00057
     advisory:     https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00057.html
     description:  Detection for arbitrary code execution in SMM
+    volume guids:
+      - 04eaaaa1-29a1-11d7-8838-00500473d4eb
   code:
     0:
       pattern: 0fb704250e040000c1e00405040100008b08

--- a/rules/UsbRt-SwSmi-CVE-2020-12301.yml
+++ b/rules/UsbRt-SwSmi-CVE-2020-12301.yml
@@ -10,6 +10,9 @@ UsbRt-SwSmi-CVE-2020-12301:
     CVSS score:   7.5 High
     advisory:     https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00367.html
     description:  Detection for SMM callout in SW SMI handler on multiple Intel server platforms
+    volume guids:
+      - dcd13040-23d8-41c6-b8f5-22281a0d64e8
+      - 04eaaaa1-29a1-11d7-8838-00500473d4eb
   guids:
     - 0:
       - name: EFI_SMM_USB_DISPATCH2_PROTOCOL_GUID

--- a/rules/UsbRt-UsbSmi-CVE-2020-12301.yml
+++ b/rules/UsbRt-UsbSmi-CVE-2020-12301.yml
@@ -10,6 +10,9 @@ UsbRt-UsbSmi-CVE-2020-12301:
     CVSS score:   7.5 High
     advisory:     https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00367.html
     description:  Detection for SMM callout in USB SMI handler on multiple Intel server platforms
+    volume guids:
+      - dcd13040-23d8-41c6-b8f5-22281a0d64e8
+      - 04eaaaa1-29a1-11d7-8838-00500473d4eb
   guids:
     - 0:
       - name: EFI_SMM_USB_DISPATCH2_PROTOCOL_GUID


### PR DESCRIPTION
This allows us to scan firmware on the LVFS by only scanning the
EFI binaries that are actually going to match.